### PR TITLE
Unable to use custom AWS credentials with SimpleEncodingLiveJobUrlOutput

### DIFF
--- a/src/common/Mapper.ts
+++ b/src/common/Mapper.ts
@@ -16,7 +16,7 @@ export function mapArray<T>(value: T[] | undefined, clazz?: Callable<T>): T[] {
 }
 
 function mapInternal<T>(value: any, clazz?: Callable<T>): T {
-  if (!value) {
+  if (!!value) {
     return value;
   }
 


### PR DESCRIPTION
Hello.

I was attempting to create a live encoding job using the simple API but was unable to. When I used the `ConsoleLogger` I noticed that my AWS S3 credentials were never sent as part of the request. This is my code that I was testing with:

```javascript
const { ConsoleLogger, SimpleEncodingLiveJobInput, SimpleEncodingLiveJobInputType, SimpleEncodingLiveJobAccessKeyCredentials, SimpleEncodingLiveJobOutput, SimpleEncodingLiveJobUrlOutput, SimpleEncodingLiveMaxResolution, SimpleEncodingLiveJobRequest, SimpleEncodingLiveCloudRegion, SimpleEncodingLiveProfile, SimpleEncodingLiveJobStatus } = require('@bitmovin/api-sdk')

const BitmovinApi = require('@bitmovin/api-sdk').default
const {kebabCase} = require('lodash')

const encodingName = `Test ${new Date().toLocaleString()}`

const bitmovinApi = new BitmovinApi({
  apiKey: 'my-bitmovin-api-key',
  logger: new ConsoleLogger()
})

main()

async function main() {
  try {
    console.info('Creating RTMP input...')
    const input = new SimpleEncodingLiveJobInput({
      inputType: SimpleEncodingLiveJobInputType.RTMP
    })
    
    console.info('Creating output credentials...')
    const outputCreds = new SimpleEncodingLiveJobAccessKeyCredentials({
      accessKey: 'my-s3-access-key',
      secretKey: 'my-s3-secret-access-key'
    })
    
    console.info('Creating S3 output...')
    const output = new SimpleEncodingLiveJobUrlOutput({
      url: `s3://my-bucket/live/${kebabCase(encodingName)}`,
      makePublic: true,
      maxResolution: SimpleEncodingLiveMaxResolution.FULL_HD,
      credentials: outputCreds
    })
    
    console.info('Creating job request...')
    const job = new SimpleEncodingLiveJobRequest({
      cloudRegion: SimpleEncodingLiveCloudRegion.AUSTRALIA,
      encodingProfile: SimpleEncodingLiveProfile.INCREASED_QUALITY,
      input,
      outputs: [output]
    })
    
    console.info('Starting job...')
    let jobResponse = await bitmovinApi.encoding.simple.jobs.live.create(job)
    let lastJobStatus = null
    
    do {
      if (jobResponse.status !== lastJobStatus) {
        console.info('Current job status:', jobResponse.status)
        lastJobStatus = jobResponse.status
      }

      if (
        jobResponse.status == SimpleEncodingLiveJobStatus.CANCELED ||
        jobResponse.status == SimpleEncodingLiveJobStatus.ERROR ||
        jobResponse.status == SimpleEncodingLiveJobStatus.FAILURE
      ) {
        break
      }

      await timeout(5000)
      jobResponse = await bitmovinApi.encoding.simple.jobs.live.get(jobResponse.id)
    }
    while (jobResponse.status != SimpleEncodingLiveJobStatus.RUNNING)

    console.info('Encoder IP:', jobResponse.encoderIp)
    console.info('Stream key:', jobResponse.streamKey)
  }
  catch (e) {
    console.error(e)
  }
}

function timeout(ms) {
  return new Promise(resolve => setTimeout(resolve, ms))
}
```

After debugging I came to the conclusion that `SimpleEncodingLiveJobUrlOutput` defaulted to `SimpleEncodingLiveJobCredentials` even though I supplied my own credentials.